### PR TITLE
Update simulate.md

### DIFF
--- a/simulate.md
+++ b/simulate.md
@@ -12,7 +12,7 @@ If you draw from the same distribution twice, will the mean of the two samples d
 **YOUR TURN:**  
 Figure out how to do a t test in R  
 Generate two vectors of 10 values drawn from N(0,1) and compare them with a t test  
-Figure out how to extract the p-value from that object (use `str` and your subsetting skills)  
+Figure out how to extract the p-value from that object (hint `names(t.test(rnorm(100), mu = .1))`)  
 Write a function simT that generates two vectors of `n` random normals, compare them with a t test and return the p-value  
 Repeat with `nrep`=20 and draw a histogram for `n`=10  
 Repeat with `nrep`=100 and draw a histogram for a `n`=10


### PR DESCRIPTION
Removed suggestion that p-value of t-tests should be obtained by subsetting `str` in favour of hinting towards direct readout of `t.test(rnorm(100))$p.value`.